### PR TITLE
Simple fix to allow extension settings to be seen.

### DIFF
--- a/src/main/groovy/cz/malohlava/VisTaskExecGraphPlugin.groovy
+++ b/src/main/groovy/cz/malohlava/VisTaskExecGraphPlugin.groovy
@@ -68,14 +68,15 @@ class VisTaskExecGraphPlugin implements Plugin<Project> {
         project.extensions.create("visteg", VisTegPluginExtension)
 
         VisTegPluginExtension vistegExt = project.visteg
-        // Unify parameters
-        if (vistegExt.colorscheme==null ||
-            !SUPPORTED_COLOR_SCHEMAS.containsKey(vistegExt.colorscheme)) {
-            LOG.warn("VisTEG colorscheme is not specified - falling back to 'spectral11' color scheme")
-            vistegExt.colorscheme = 'spectral11'
-        }
-        if (vistegExt.enabled) {
-            project.gradle.taskGraph.whenReady { g ->
+
+        project.gradle.taskGraph.whenReady { g ->
+            if (vistegExt.enabled) {
+                // Unify parameters
+                if (vistegExt.colorscheme==null ||
+                    !SUPPORTED_COLOR_SCHEMAS.containsKey(vistegExt.colorscheme)) {
+                    LOG.warn("VisTEG colorscheme is not specified - falling back to 'spectral11' color scheme")
+                    vistegExt.colorscheme = 'spectral11'
+                }
                 // Access private variables of tasks graph
                 def tep = getTEP(g)
                 // Execution starts on these tasks


### PR DESCRIPTION
The evaluation of the extension settings must be
done in the listener handler to allow the project
evaluation to take effect. Without this change the
enabled property or the validation of the selected
colorscheme value will simply have no effect.

The changes here simply move the enabled option
evaluation and the validation of colorscheme code.
Tested manually since there was not much in the way
of unit tests for this plugin already.

If you prefer to have unit tests added for this let me know.
