### PR TITLE
Fix compatibility with gradle 4.2, Remove obsolete import of unused code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,12 +41,13 @@ plugindev {
 }
 
 /* Credentials are stored in ~./gradle/gradle.properties file. */
-bintray {
-    user = "$bintrayUser"
-    key = "$bintrayApiKey"
-    pkg.repo = 'gradle-plugins'
+if (project.hasProperty('bintrayUser')) {
+    bintray {
+        user = "$bintrayUser"
+        key = "$bintrayApiKey"
+        pkg.repo = 'gradle-plugins'
+    }
 }
-
 
 // Gradle wrapper generator
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
Add dryRun option to prevent execution of tasks
Fix only apply bintray if bintrayUser is defined

@mmalohlava it would be great if you could merge this and release a new version soon